### PR TITLE
Adds nicknames to load character menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -394,13 +394,16 @@ datum/preferences
 	if(S)
 		dat += "<b>Select a character slot to load</b><hr>"
 		var/name
+		var/nickname // ARFS add - Nicknames shown next to the character slot (helps to show which one's which)
 		for(var/i=1, i<= config.character_slots, i++)
 			S.cd = "/character[i]"
 			S["real_name"] >> name
+			S["nickname"] >> nickname // ARFS add - Nickname var to add to character loadout stuff
 			if(!name)	name = "Character[i]"
 			if(i==default_slot)
 				name = "<b>[name]</b>"
-			dat += "<a href='?src=\ref[src];changeslot=[i]'>[name]</a><br>"
+			dat += "<a href='?src=\ref[src];changeslot=[i]'>[name][nickname ? " ([nickname])" : ""]</a><br>" // ARFS edit again! I hate making comments like this, it gets pretty messy, totally should use git blame to see modifications by others!
+
 
 	dat += "<hr>"
 	dat += "</center></tt>"


### PR DESCRIPTION
As the title says! This is what it looks like in-game:

![image](https://user-images.githubusercontent.com/68038883/87510110-dc1de080-c66a-11ea-8b03-0d01c3037cab.png)

I think this is useful because having multple of the same character slots can be quite hard to manage. If you have different nicknames for each slot like I do then it'll be a great way to sort out which slot does what.

ye. pls approve me love u long time